### PR TITLE
Fix: Python hard coded path different on CloudService vms

### DIFF
--- a/windows.ps1
+++ b/windows.ps1
@@ -19,8 +19,11 @@ if($exists)
     Unregister-ScheduledTask -Confirm:$false -TaskName "batchappinsights";
 }
 
+$pythonPath = get-command python | Select-OBject -ExpandProperty Definition
+Write-Host "Resolved python path to $pythonPath"
+
 Write-Host "Starting App insights background process in $env:AZ_BATCH_TASK_WORKING_DIR"
-$action = New-ScheduledTaskAction -WorkingDirectory $env:AZ_BATCH_TASK_WORKING_DIR -Execute 'Powershell.exe' -Argument "Start-Process C:\Python36\python.exe -ArgumentList ('.\nodestats.py','$env:AZ_BATCH_POOL_ID', '$env:AZ_BATCH_NODE_ID', '$env:APP_INSIGHTS_INSTRUMENTATION_KEY')  -RedirectStandardOutput .\node-stats.log -RedirectStandardError .\node-stats.err.log -NoNewWindow"  
+$action = New-ScheduledTaskAction -WorkingDirectory $env:AZ_BATCH_TASK_WORKING_DIR -Execute 'Powershell.exe' -Argument "Start-Process $pythonPath -ArgumentList ('.\nodestats.py','$env:AZ_BATCH_POOL_ID', '$env:AZ_BATCH_NODE_ID', '$env:APP_INSIGHTS_INSTRUMENTATION_KEY')  -RedirectStandardOutput .\node-stats.log -RedirectStandardError .\node-stats.err.log -NoNewWindow"  
 $principal = New-ScheduledTaskPrincipal -UserID 'NT AUTHORITY\SYSTEM' -LogonType ServiceAccount -RunLevel Highest ; 
 Register-ScheduledTask -Action $action -Principal $principal -TaskName "batchappinsights" -Force ; 
 Start-ScheduledTask -TaskName "batchappinsights"; 


### PR DESCRIPTION
This will retrieve the path to the python exe and pass the expanded value to the scheduled task.